### PR TITLE
Fix chatbox partial visibility on main page

### DIFF
--- a/LibraryManagement.WebUI/Views/Kullanici/_ChatBoxPartial.cshtml
+++ b/LibraryManagement.WebUI/Views/Kullanici/_ChatBoxPartial.cshtml
@@ -1,4 +1,4 @@
-﻿<button class="fixed bottom-12 cursor-pointer right-6 z-50 bg-yellow-300 hover:bg-yellow-400 rounded-full p-4 shadow-lg flex items-center justify-center transition"
+﻿<button id="openChat" class="fixed bottom-12 cursor-pointer right-6 z-50 bg-yellow-300 hover:bg-yellow-400 rounded-full p-4 shadow-lg flex items-center justify-center transition"
         aria-label="Chat with AI">
     <svg width="28" height="28" viewBox="0 0 24 24" fill="none" class="block"
          xmlns="http://www.w3.org/2000/svg">

--- a/LibraryManagement.WebUI/wwwroot/js/ChatBox.js
+++ b/LibraryManagement.WebUI/wwwroot/js/ChatBox.js
@@ -2,6 +2,15 @@
     .withUrl("/ai-hub")
     .build();
 
+// Toggle chat visibility
+const chatBoxContainer = document.getElementById('chatBox');
+document.getElementById('openChat').addEventListener('click', () => {
+    chatBoxContainer.classList.remove('scale-0', 'opacity-0');
+});
+document.getElementById('closeChat').addEventListener('click', () => {
+    chatBoxContainer.classList.add('scale-0', 'opacity-0');
+});
+
 async function startHubConnection() {
     try {
         await hubConnection.start();


### PR DESCRIPTION
## Summary
- Make chat trigger button identifiable and accessible from script
- Add JavaScript to toggle chat box visibility when button is clicked

## Testing
- `npm test` (fails: Missing script "test")
- `dotnet build` (fails: command not found)
- `apt-get update` (fails: repository not signed)

------
https://chatgpt.com/codex/tasks/task_e_68946a46fc5c8320bc343a9e4945823e